### PR TITLE
bin/edit - Include Git files

### DIFF
--- a/bin/edit
+++ b/bin/edit
@@ -11,7 +11,7 @@
 # If file argument starts with /tmp we run in foreground mode so
 # commands like "crontab -e" do not fail.
 OPTS=""
-if [[ "$1" == /tmp/* ]]; then
+if [[ "$1" == /tmp/* ]] || [[ "$1" == */.git/* ]]; then
     OPTS="-w"
 fi
 


### PR DESCRIPTION
Since Git uses the `.git/` subdirectory to store temporary files for editing (such as `COMMIT_EDITMSG`), this modification will also enable VSCode to work with those.